### PR TITLE
Fix devices not mapping if there are no partitions

### DIFF
--- a/pyalarmdotcomajax/__init__.py
+++ b/pyalarmdotcomajax/__init__.py
@@ -289,21 +289,20 @@ class AlarmController:
 
             raw_devices.remove(partition_raw)
 
-            #
-            # BUILD ALL DEVICES IN PARTITION
-            #
-            # This ensures that partition map is built before devices are built.
+        #
+        # BUILD DEVICES
+        #
 
-            for device_raw in raw_devices:
-                try:
-                    device_instance: AllDevices_t = await self._async_update__build_device(
-                        device_raw, device_type_specific_data, extension_results
-                    )
+        for device_raw in raw_devices:
+            try:
+                device_instance: AllDevices_t = await self._async_update__build_device(
+                    device_raw, device_type_specific_data, extension_results
+                )
 
-                    device_instances.update({device_instance.id_: device_instance})
+                device_instances.update({device_instance.id_: device_instance})
 
-                except UnsupportedDeviceType:
-                    continue
+            except UnsupportedDeviceType:
+                continue
 
         self.devices.update(device_instances, purge=True)
 


### PR DESCRIPTION
In `AlarmController.async_update`, the mapping loop prevents accounts with no partitions from being mapped, since the loop would only run if you had at least one partition. We can resolve this by handling the device mapping after the partition mapping, rather than during.

If I had to guess, it looked like there was a reason this was done. Without this, though, this library and the Home Assistant component are unusable unless you're able to set up a partition (and since my setup is actually managed by my apartment, I can't). If a user who has partitions could try this on their side to verify everything is OK before merge, that would be appreciated.