### PR TITLE
checkout for existing callbacks and copy them to newly created devices

### DIFF
--- a/pyalarmdotcomajax/__init__.py
+++ b/pyalarmdotcomajax/__init__.py
@@ -310,7 +310,7 @@ class AlarmController:
             try:
                 existing_callback = self.devices.get(existing_id).external_update_callback
                 device_instances[existing_id].external_update_callback = existing_callback
-            
+
             except UnkonwnDevice as e:
                 continue
 

--- a/pyalarmdotcomajax/__init__.py
+++ b/pyalarmdotcomajax/__init__.py
@@ -38,6 +38,7 @@ from pyalarmdotcomajax.exceptions import (
     SessionTimeout,
     TryAgain,
     UnexpectedResponse,
+    UnkonwnDevice,
     UnsupportedDeviceType,
 )
 from pyalarmdotcomajax.extensions import (
@@ -303,6 +304,14 @@ class AlarmController:
                 device_instances.update({device_instance.id_: device_instance})
 
             except UnsupportedDeviceType:
+                continue
+
+        for existing_id in device_instances:
+            try:
+                existing_callback = self.devices.get(existing_id).external_update_callback
+                device_instances[existing_id].external_update_callback = existing_callback
+            
+            except UnkonwnDevice as e:
                 continue
 
         self.devices.update(device_instances, purge=True)

--- a/pyalarmdotcomajax/__init__.py
+++ b/pyalarmdotcomajax/__init__.py
@@ -311,7 +311,7 @@ class AlarmController:
                 existing_callback = self.devices.get(existing_id).external_update_callback
                 device_instances[existing_id].external_update_callback = existing_callback
 
-            except UnkonwnDevice as e:
+            except UnkonwnDevice:
                 continue
 
         self.devices.update(device_instances, purge=True)


### PR DESCRIPTION
This hack demonstrates the fix I used for issue 288 in alarmdotcom integration.  Polling of devices actually recreates each device, losing all the initial callback events that were created at Home Assistant's start.  This hack simply checks for existing devices and copies their callbacks.