### PR TITLE
Update __init__.py to set default value for logoName attribute

### DIFF
--- a/pyalarmdotcomajax/__init__.py
+++ b/pyalarmdotcomajax/__init__.py
@@ -569,10 +569,13 @@ class AlarmController:
             json_rsp = await resp.json()
 
             try:
-                self._user_id = json_rsp["data"][0]["id"]
                 self._provider_name = json_rsp["data"][0]["attributes"]["logoName"]
-                self._provider_name = json_rsp["data"][0]["attributes"]["logoName"]
+            except (KeyError, IndexError) as err:
+                self._provider_name = "Alarm.com"
 
+            try:
+                self._user_id = json_rsp["data"][0]["id"]
+            
                 for inclusion in json_rsp["included"]:
                     if inclusion["id"] == self._user_id and inclusion["type"] == "profile/profile":
                         self._user_email = inclusion["attributes"]["loginEmailAddress"]


### PR DESCRIPTION
This addresses issue #440 in the alarmdotcom project. pyalarmdotcom/alarmdotcom#440
Issue #145 here.
pyalarmdotcom/pyalarmdotcomajax#145

Something changed in the response alarm.com returns on login, leaving out the "logoName" attribute. This causes pyalarmdotcomajax to terminate the authentication process as failed.

This change is to fill in a default value for that attribute in the case that it is missing from the alarm.com response.