### PR TITLE
Introduce controller registry and image sensor orchestrator

### DIFF
--- a/pyalarmdotcomajax/controllers/device_catalogs.py
+++ b/pyalarmdotcomajax/controllers/device_catalogs.py
@@ -1,6 +1,7 @@
 """Alarm.com controller for systems."""
 
 import logging
+from typing import ClassVar
 
 from pyalarmdotcomajax.controllers.base import BaseController
 from pyalarmdotcomajax.models.base import ResourceType
@@ -15,3 +16,16 @@ class DeviceCatalogController(BaseController[DeviceCatalog]):
     resource_type = ResourceType.DEVICE_CATALOG
     _resource_class = DeviceCatalog
     _requires_target_ids = True
+    related_types: ClassVar[list[ResourceType]] = [
+        ResourceType.SENSOR,
+        ResourceType.CAMERA,
+        ResourceType.GARAGE_DOOR,
+        ResourceType.GATE,
+        ResourceType.LIGHT,
+        ResourceType.LOCK,
+        ResourceType.PARTITION,
+        ResourceType.THERMOSTAT,
+        ResourceType.WATER_SENSOR,
+        ResourceType.WATER_VALVE,
+        ResourceType.IMAGE_SENSOR,
+    ]

--- a/pyalarmdotcomajax/controllers/image_sensors.py
+++ b/pyalarmdotcomajax/controllers/image_sensors.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from enum import StrEnum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from pyalarmdotcomajax.adc.util import Param_Id, cli_action
 from pyalarmdotcomajax.controllers.base import BaseController, device_controller
@@ -36,6 +36,7 @@ class ImageSensorController(BaseController[ImageSensor]):
     _supported_resource_events = SupportedResourceEvents(
         events=[ResourceEventType.ImageSensorUpload]
     )
+    related_types: ClassVar[list[ResourceType]] = [ResourceType.IMAGE_SENSOR_IMAGE]
 
     @cli_action()
     async def peek_in(self, id: Param_Id) -> None:
@@ -72,9 +73,8 @@ class ImageSensorController(BaseController[ImageSensor]):
         return adc_resource
 
 
+@device_controller(ResourceType.IMAGE_SENSOR_IMAGE, ImageSensorImage)
 class ImageSensorImageController(BaseController[ImageSensorImage]):
     """Controller for image sensor images."""
 
-    resource_type = ResourceType.IMAGE_SENSOR_IMAGE
-    _resource_class = ImageSensorImage
     _resource_url_override = "imageSensor/imageSensorImages/getRecentImages"

--- a/pyalarmdotcomajax/controllers/registry.py
+++ b/pyalarmdotcomajax/controllers/registry.py
@@ -1,0 +1,14 @@
+"""Global registry for Alarm.com controllers."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pyalarmdotcomajax.models.base import ResourceType  # noqa: TC001
+
+if TYPE_CHECKING:
+    from .base import BaseController
+
+# Map ResourceType to controller class
+CONTROLLER_REGISTRY: dict[ResourceType, type[BaseController]] = {}
+

--- a/pyalarmdotcomajax/orchestrators/image_sensors.py
+++ b/pyalarmdotcomajax/orchestrators/image_sensors.py
@@ -1,0 +1,66 @@
+"""Orchestrator for image sensor resources."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from pyalarmdotcomajax.events import EventBrokerMessage, EventBrokerTopic, ResourceEventMessage
+from pyalarmdotcomajax.models.image_sensor import ImageSensor, ImageSensorImage
+from pyalarmdotcomajax.websocket.messages import EventWSMessage, ResourceEventType
+
+if TYPE_CHECKING:
+    from pyalarmdotcomajax import AlarmBridge
+
+log = logging.getLogger(__name__)
+
+
+class ImageSensorOrchestrator:
+    """Coordinate image sensors and their images."""
+
+    def __init__(self, bridge: AlarmBridge) -> None:
+        self._bridge = bridge
+        self._bridge.events.subscribe(EventBrokerTopic.RAW_RESOURCE_EVENT, self._on_ws_event)
+        self._bridge.events.subscribe([
+            EventBrokerTopic.RESOURCE_ADDED,
+            EventBrokerTopic.RESOURCE_UPDATED,
+        ], self._on_image_event)
+
+    async def _on_ws_event(self, message: EventBrokerMessage) -> None:
+        """Handle websocket events for image uploads."""
+
+        if not isinstance(message, ResourceEventMessage):
+            return
+        resource = message.resource
+        if not isinstance(resource, ImageSensor):
+            return
+        ws_msg = getattr(message, "ws_message", None)
+        if isinstance(ws_msg, EventWSMessage) and ws_msg.subtype == ResourceEventType.ImageSensorUpload:
+            await self._refresh_images(resource.id)
+
+    async def _on_image_event(self, message: EventBrokerMessage) -> None:
+        """Link new images to their parent sensors."""
+
+        if not isinstance(message, ResourceEventMessage):
+            return
+        if not isinstance(message.resource, ImageSensorImage):
+            return
+        sensor_id = message.resource.image_sensor_id
+        if sensor_id is None:
+            return
+        sensor = self._bridge.image_sensors.get(sensor_id)
+        if sensor:
+            await sensor._on_new_image([message.resource])  # noqa: SLF001
+
+    async def _refresh_images(self, sensor_id: str) -> None:
+        """Refresh images for a sensor and update sensor state."""
+
+        await self._bridge.image_sensor_images.initialize([sensor_id])
+        images = [
+            image
+            for image in self._bridge.image_sensor_images.items
+            if image.image_sensor_id == sensor_id
+        ]
+        sensor = self._bridge.image_sensors.get(sensor_id)
+        if sensor:
+            await sensor._on_new_image(images)  # noqa: SLF001


### PR DESCRIPTION
## Summary
- add a global controller registry and register controllers via `device_controller`
- support explicit related types for controllers
- create an orchestrator that keeps image sensors in sync with their images
- expose dynamic controller management on `AlarmBridge`

## Testing
- `ruff check --fix .`
- `mypy pyalarmdotcomajax` *(fails: Class cannot subclass SerializableType, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_683f42055f1883288dd0fd14d143fac0