### PR TITLE
Fix fan_mode + fan_mode_duration rejection in set_state

### DIFF
--- a/pyalarmdotcomajax/controllers/thermostats.py
+++ b/pyalarmdotcomajax/controllers/thermostats.py
@@ -135,7 +135,6 @@ class ThermostatController(BaseController[Thermostat]):
             attrib_list := [
                 state,
                 fan_mode,
-                fan_mode_duration,
                 cool_setpoint,
                 heat_setpoint,
                 schedule_mode,


### PR DESCRIPTION
This fixes a logic bug in `set_state()` where passing both `--fan-mode` and `--fan-mode-duration` would incorrectly raise a "only one attribute at a time" error — even though that combination is supposed to be allowed.

The issue was that `fan_mode_duration` was being treated as a separate top-level attribute in the mutual exclusivity check. So even when used correctly (with `fan_mode`), it got flagged.

### What changed
- Removed `fan_mode_duration` from the list of mutually exclusive fields.
- The check that enforces `fan_mode` and `fan_mode_duration` must be passed together is still in place.

### Why it matters
This unblocks valid usage patterns — including Home Assistant and CLI calls — that need to set both `fan_mode` and `fan_mode_duration` together.